### PR TITLE
Add MQTT Support to Solariot

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ Data can then be visualised using a free dashboard service from
 [Freeboard](https://freeboard.io/). You'll need to create your own dashboard,
 using dweet.io as your data source.
 
+### MQTT Support
+
+This is a good way to push data to MQTT topics that you might subscribe various tools 
+such as Node-Red or Home Assistant to. Running your own MQTT server will mean you can
+also retrieve these values when your internet is offline.
+
+All you need to do is to set the `mqtt_server`, `mqtt_port` and `mqtt_topic` values in
+`config.py` file and you'll be up and running.
+
 ### InfluxDB and Grafana
 
 Use a time series database such as 

--- a/config-example.py
+++ b/config-example.py
@@ -17,3 +17,7 @@ influxdb_password = "password"
 influxdb_database = "inverter"
 influxdb_ssl = True
 influxdb_verify_ssl = False
+# Optional
+mqtt_server = "192.168.1.128"
+mqtt_port = 1883
+mqtt_topic = "inverter/stats"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+paho-mqtt>=1.4.0
 pymodbus>=1.3.2
 dweepy>=0.3.0
 influxdb>=2.17.0


### PR DESCRIPTION
This uses Paho-MQTT Library to add mqtt publish support for solariot. I use it extensively in Node-red to trigger workflows based on grid status (if off grid, disable a bunch of power hungry devices that might be running).