### PR TITLE
Enable TLS MQTT support 

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -17,9 +17,10 @@ influxdb_password = "password"
 influxdb_database = "inverter"
 influxdb_ssl = True
 influxdb_verify_ssl = False
+
 # Optional
-mqtt_server = "192.168.1.128"
-mqtt_port = 1883
-mqtt_topic = "inverter/stats"
-mqtt_username = "user"
-mqtt_password = "password"
+#mqtt_server = "192.168.1.128"
+#mqtt_port = 1883
+#mqtt_topic = "inverter/stats"
+#mqtt_username = "user"
+#mqtt_password = "password"

--- a/solariot.py
+++ b/solariot.py
@@ -84,7 +84,7 @@ if hasattr(config, "mqtt_server"):
     if hasattr(config, "mqtt_username") and hasattr(config, "mqtt_password"):
         mqtt_client.username_pw_set(config.mqtt_username, config.mqtt_password)
 
-    if config.mqtt_port == 8333:
+    if config.mqtt_port == 8883:
         mqtt_client.tls_set()
 
     mqtt_client.connect(config.mqtt_server, port=config.mqtt_port)

--- a/solariot.py
+++ b/solariot.py
@@ -77,13 +77,19 @@ print("Connect")
 client.connect()
 client.close()
 
-try: 
-  mqtt_client = mqtt.Client('pv_data')
-  if 'config.mqtt_username' in globals():
-      mqtt_client.username_pw_set(config.mqtt_username,config.mqtt_password)
-  mqtt_client.connect(config.mqtt_server, port=config.mqtt_port)
-except:
-  mqtt_client = None
+# Configure MQTT
+if hasattr(config, "mqtt_server"):
+    mqtt_client = mqtt.Client(getattr(config, "mqtt_client_name", "pv_data"))
+
+    if hasattr(config, "mqtt_username") and hasattr(config, "mqtt_password"):
+        mqtt_client.username_pw_set(config.mqtt_username, config.mqtt_password)
+
+    if config.mqtt_port == 8333:
+        mqtt_client.tls_set()
+
+    mqtt_client.connect(config.mqtt_server, port=config.mqtt_port)
+else:
+    mqtt_client = None
 
 try:
   flux_client = InfluxDBClient(config.influxdb_ip,


### PR DESCRIPTION
This PR adds 'really basic not very flexible' MQTT TLS support (which supports my use case at least).

We call the `tls_set()` method before calling `connect()` on the mqtt client if the port number is the 'commonly used' TLS port for MQTT (see https://pypi.org/project/paho-mqtt/#option-functions for method)

I've also done a bit of revamping of some of the config handing within MQTT to make it a bit more flexible!
As part of this I've commented out the 'mqtt variables' by default in the `config-examples.py` as I'd expect users to uncomment them for new installations if required. This shouldn't be a breaking change from what I can see.

Happy to update/adjust as necessary!