### PR TITLE
Bringing in pvoutput publishing and minor improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+config.py
+__pycache__
+venv

--- a/.dockeringore
+++ b/.dockeringore
@@ -1,0 +1,3 @@
+config.py
+__pycache__/
+venv/

--- a/.dockeringore
+++ b/.dockeringore
@@ -1,3 +1,0 @@
-config.py
-__pycache__/
-venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ COPY . /solariot/
 
 RUN pip3 install --upgrade pip wheel && pip3 install --upgrade -r requirements.txt
 
-CMD ["solariot.py"]
+ENV PYTHONPATH="/config:$PYTHONPATH"
+
+CMD ["python3", "solariot.py"]

--- a/README.md
+++ b/README.md
@@ -5,15 +5,12 @@ data to a real time dashboard.
 
 Solariot will connect directly to your Inverter using Modbus TCP. 
 
-Currently, Solariot is able to talk to a SMA Sunny Boy and Sungrow SH5K inverter. However,
-the script is designed to allow any Modbus TCP enabled Inverter to be queried by
-using your own Modbus register map file.
+Currently, Solariot is able to talk to a SMA Sunny Boy and Sungrow SH5K & SG5KD inverters.
+Solariot is designed to allow any Modbus TCP enabled inverter to be queried using a Modbus register map.
 
-Data is collected and can be streamed to destinations like dweet.io or InfluxDB. 
-Next, use a dashboard to display the metrics or set triggers to manage your appliances. 
-
-For a dashboard example, see Meltaxa's Grafana dashboard on <a href="https://solarspy.live">solarspy.live</a>. 
-A recent screenshot is shown below:
+Data is collected and can be streamed to destinations like dweet.io, MQTT, InfluxDB or PVOutput.
+To visual the telemetry, use a dashboard such as Grafana. For example, this is Meltaxa's Grafana dashboard on
+<a href="https://solarspy.live">solarspy.live</a>:
 <p align="center">
   <!--- 
   Github will by default use it's Camo CDN to cache images (https://github.blog/2014-01-28-proxying-user-images/). 
@@ -108,7 +105,8 @@ We offer direct integration to publishing metrics to the 'Add Status' [API endpo
 
 Supported values are `v1` through to `v6` and an assumption that `v1` and `v3` are values are incremental and reset every day.
 
-All you need to do is set the `pvoutput_api` and `pvoutput_sid` values in `config.py` file and you'll be publishing in no time!
+All you need to do is set the `pvoutput_api` and `pvoutput_sid` and `pvoutput_rate_limit` values in `config.py` file and
+you'll be publishing in no time!
 
 ## Integration with PVOutput.org and Grafana
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ either install your own Grafana server or use their free
 A json export of solarspy.live Grafana dashboard is available under the grafana folder.
 The file will require editing to match your InfluxDb settings.
 
+### PVOutput.org
+
+We offer direct integration to publishing metrics to the 'Add Status' [API endpoint](https://pvoutput.org/help.html#api-addstatus) of PVOutput.
+
+Supported values are `v1` through to `v6` and an assumption that `v1` and `v3` are values are incremental and reset every day.
+
+All you need to do is set the `pvoutput_api` and `pvoutput_sid` values in `config.py` file and you'll be publishing in no time!
+
 ## Integration with PVOutput.org and Grafana
 
 If you are using Grafana as your dashboard, a neat little trick is to then

--- a/config-example.py
+++ b/config-example.py
@@ -24,3 +24,7 @@ influxdb_verify_ssl = False
 #mqtt_topic = "inverter/stats"
 #mqtt_username = "user"
 #mqtt_password = "password"
+
+# Optional
+#pvoutput_api = "api_key"
+#pvoutput_sid = "system_id"

--- a/config-example.py
+++ b/config-example.py
@@ -28,3 +28,5 @@ influxdb_verify_ssl = False
 # Optional
 #pvoutput_api = "api_key"
 #pvoutput_sid = "system_id"
+# 12 for regular accounts, 60 for donation accounts
+#pvoutput_rate_limit = 60

--- a/modbus-sungrow-sg5kd.py
+++ b/modbus-sungrow-sg5kd.py
@@ -1,16 +1,22 @@
 read_register = {
-  "5003":  "daily_power_yield_10",
-  "5004":  "total_power_yield",
-  "5008":  "internal_temp_10",
-  "5011":  "pv1_voltage_10",
-  "5012":  "pv1_current_10",
-  "5013":  "pv2_voltage_10",
-  "5014":  "pv2_current_10",
-  "5017":  "total_pv_power",
-  "5019":  "grid_voltage_10",
-  "5022":  "inverter_current_10",
-  "5031":  "total_active_power",
-  "5036":  "grid_frequency_10",
+  "5003": "daily_power_yield_0.01",  # Wh
+  "5004": "total_power_yield_100",  # MWh
+  "5008": "internal_temp_10",  # C
+  "5011": "pv1_voltage_10",  # V
+  "5012": "pv1_current_10",  # A
+  "5013": "pv2_voltage_10",  # V
+  "5014": "pv2_current_10",  # A
+  "5017": "total_pv_power",  # W
+  "5019": "grid_voltage_10",  # V
+  "5022": "inverter_current_10", # A
+  "5031": "total_active_power",  # W
+  "5036": "grid_frequency_10",  # Hz
+
+  "5091": "power_meter",  # W - House Consumption
+  "5097": "daily_purchased_energy_10", # kW
+
+  "5101": "daily_energy_consumption_0.01", # Wh
+  "5103": "total_energy_consumption_10", # kWh
 }
 
 holding_register = {
@@ -23,16 +29,20 @@ holding_register = {
 }
 
 scan = """{
-  "read": [
-     {
-       "start": "5000",
-       "range": "40"
-     }
+    "read": [
+        {
+            "start": "5000",
+            "range": "100"
+        },
+        {
+            "start": "5100",
+            "range": "50"
+        }
   ],
   "holding": [
     {
       "start": "4999",
-      "range": "100"
+      "range": "10"
     }
   ]
 }"""

--- a/modbus-sungrow-sg5kd.py
+++ b/modbus-sungrow-sg5kd.py
@@ -1,22 +1,22 @@
 read_register = {
-  "5003": "daily_power_yield_0.01",  # Wh
+  "5003": "daily_power_yield_0.01", # Wh
   "5004": "total_power_yield_100",  # MWh
-  "5008": "internal_temp_10",  # C
-  "5011": "pv1_voltage_10",  # V
-  "5012": "pv1_current_10",  # A
-  "5013": "pv2_voltage_10",  # V
-  "5014": "pv2_current_10",  # A
-  "5017": "total_pv_power",  # W
-  "5019": "grid_voltage_10",  # V
-  "5022": "inverter_current_10", # A
-  "5031": "total_active_power",  # W
-  "5036": "grid_frequency_10",  # Hz
+  "5008": "internal_temp_10",       # C
+  "5011": "pv1_voltage_10",         # V
+  "5012": "pv1_current_10",         # A
+  "5013": "pv2_voltage_10",         # V
+  "5014": "pv2_current_10",         # A
+  "5017": "total_pv_power",         # W
+  "5019": "grid_voltage_10",        # V
+  "5022": "inverter_current_10",    # A
+  "5031": "total_active_power",     # W
+  "5036": "grid_frequency_10",      # Hz
 
-  "5091": "power_meter",  # W - House Consumption
+  "5091": "power_meter",               # W - House Consumption
   "5097": "daily_purchased_energy_10", # kW
 
   "5101": "daily_energy_consumption_0.01", # Wh
-  "5103": "total_energy_consumption_10", # kWh
+  "5103": "total_energy_consumption_10",   # kWh
 }
 
 holding_register = {
@@ -46,3 +46,14 @@ scan = """{
     }
   ]
 }"""
+
+# Match Modbus registers to pvoutput api fields
+# Reference: https://pvoutput.org/help.html#api-addstatus
+pvoutput = {
+  "Energy Generation": "daily_power_yield",
+  "Power Generation": "total_active_power",
+  "Energy Consumption": "daily_energy_consumption",
+  "Power Consumption": "power_meter",
+  "Temperature": "internal_temp",
+  "Voltage": "grid_voltage"
+}

--- a/modbus-sungrow-sh5k.py
+++ b/modbus-sungrow-sh5k.py
@@ -91,3 +91,14 @@ scan = """{
      }
   ]
 }"""
+
+# Match Modbus registers to pvoutput api fields
+# Reference: https://pvoutput.org/help.html#api-addstatus
+pvoutput = {
+  "Energy Generation": "daily_pv_energy",
+  "Power Generation": "total_pv_power",
+  "Energy Consumption": "daily_use_energy",
+  "Power Consumption": "load_power",
+  "Temperature": "internal_temp",
+  "Voltage": "grid_voltage"
+}

--- a/solariot.py
+++ b/solariot.py
@@ -201,7 +201,7 @@ if hasattr(config, "pvoutput_api"):
             if response.status_code != requests.codes.ok:
                 raise RuntimeError(response.text)
             else:
-                logging.info("Successfully posted status update to PVOutput")
+                logging.debug("Successfully posted status update to PVOutput")
 
     pvoutput_client = PVOutputPublisher(config.pvoutput_api, config.pvoutput_sid)
 

--- a/solariot.py
+++ b/solariot.py
@@ -347,6 +347,7 @@ def publish_mqtt(inverter):
     result.wait_for_publish()
 
     if result.rc != mqtt.MQTT_ERR_SUCCESS:
+        # See https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L149 for error code mapping
         logging.error(f"Failed to publish to MQTT with error code: {result.rc}")
     else:
         logging.info("Published to MQTT")

--- a/solariot.py
+++ b/solariot.py
@@ -170,6 +170,8 @@ if hasattr(config, "pvoutput_api"):
             * v5 - Inverter Temperature
             * v6 - Voltage (we post Grid voltage)
             """
+            at_least_one_of = set(["v1", "v2", "v3", "v4"])
+
             now = datetime.datetime.now()
 
             parameters = {
@@ -195,6 +197,9 @@ if hasattr(config, "pvoutput_api"):
 
             if "grid_voltage" in metrics:
                 parameters["v6"] = metrics["grid_voltage"]
+
+            if not at_least_one_of.intersection(parameters.keys()):
+                raise RuntimeError("Metrics => PVOutput mapping failed, please review metric names and update")
 
             response = requests.request("POST", url=self.status_url, headers=self.headers, params=parameters)
 

--- a/solariot.py
+++ b/solariot.py
@@ -232,6 +232,7 @@ def load_registers(register_type, start, count=100):
             raise RuntimeError(f"Unsupported register type: {type}")
     except Exception as err:
         logging.warning("No data. Try increasing the timeout or scan interval.")
+        return False
 
     if rr.isError():
         logging.warning("Modbus connection failed")

--- a/solariot.py
+++ b/solariot.py
@@ -340,8 +340,17 @@ def publish_dweepy(inverter):
     return result
 
 def publish_mqtt(inverter):
+    # After a while you'll need to reconnect, so just reconnect before each publish
+    mqtt_client.reconnect()
+
     result = mqtt_client.publish(config.mqtt_topic, json.dumps(inverter).replace('"', '\"'))
-    logging.info("Published to MQTT")
+    result.wait_for_publish()
+
+    if result.rc != mqtt.MQTT_ERR_SUCCESS:
+        logging.error(f"Failed to publish to MQTT with error code: {result.rc}")
+    else:
+        logging.info("Published to MQTT")
+
     return result
 
 def publish_pvoutput(inverter):


### PR DESCRIPTION
This was pulled from https://github.com/corvax/solariot/commit/d4146205acde600233eca1d967c86178337bda18
So credits to @corvax for the hard work!
I've just tweaked it by wrapping it in a class to make it a bit more modular/portable as well as expanding on the other `vX` parameters you can provide to pvoutput!

Additional features as I was doing this all at once:
* Modbus maps can now have `metric_100` or `metric_10000` to have the script divide by that figure to get you to the target decimal (this can even be say... `metric_0.01` to move the decimal place to the right!)
* Updates to the sg5kd.py to track a few more metrics and adding comments to the 'units' these metrics produce (W vs kW vs MWh etc), I've made a number of these from `kW => W` because PVOutput tracks stuff in W
* Made the solariot.py script default to python3 now as we kinda need it
* Improved MQTT publishing by reconnecting before sending, as after a while I was seeing MQTT_ERR_NO_CONN which indicated the client dropped the connection to the broker
* Adding a .dockerignore file that will not accidentally include any potentially sensitive files into your locally built docker image ;)

This closes #22 