### PR TITLE
Implementing some weird-ass multi-register logic around positive/negative values

### DIFF
--- a/modbus-sungrow-sg5kd.py
+++ b/modbus-sungrow-sg5kd.py
@@ -12,9 +12,11 @@ read_register = {
   "5031": "total_active_power",     # W
   "5036": "grid_frequency_10",      # Hz
 
-  "5091": "power_meter",               # W - House Consumption
-  "5097": "daily_purchased_energy_10", # kW
+  "5083": "export_power_overflow",  # W - House Grid Consumption (+ = importing, - = exporting)
+  "5084": "export_power_indicator", # W - House Grid Consumption Overflow Indicator
+  "5091": "power_meter",            # W - House Overall Consumption
 
+  "5097": "daily_purchased_energy_10", # kW
   "5101": "daily_energy_consumption_0.01", # Wh
   "5103": "total_energy_consumption_10",   # kWh
 }

--- a/solariot.py
+++ b/solariot.py
@@ -265,7 +265,6 @@ def load_registers(register_type, start, count=100):
         return
 
     overflow_regex = re.compile(r"(?P<register_name>[a-zA-Z0-9_\.]+)_overflow$")
-    indicator_regex = re.compile(r"(?P<register_name>[a-zA-Z0-9_\.]+)_indicator$")
     divide_regex = re.compile(r"(?P<register_name>[a-zA-Z0-9_]+)_(?P<divide_by>[0-9\.]+)$")
 
     for num in range(0, count):

--- a/solariot.py
+++ b/solariot.py
@@ -417,6 +417,16 @@ def publish_pvoutput(inverter):
         logging.info("Published to PVOutput")
     return result
 
+def save_json(inverter):
+    try:
+        f = open(config.json_file,'w')
+        f.write(json.dumps(inverter))
+        f.close()
+    except Exception as err:
+        logging.error("Error writing telemetry to file: %s" % err)
+        return
+    logging.info("Inverter telemetry written to %s file." % config.json_file)
+
 # Core monitoring loop
 def scrape_inverter():
     """ Connect to the inverter and scrape the metrics """
@@ -494,6 +504,10 @@ while True:
 
     if pvoutput_client is not None:
         t = Thread(target=publish_pvoutput, args=(inverter,))
+        t.start()
+
+    if hasattr(config, "json_file"):
+        t = Thread(target=save_json, args=(inverter,))
         t.start()
 
     if args.one_shot:

--- a/solariot.py
+++ b/solariot.py
@@ -460,7 +460,7 @@ def scrape_inverter():
 
     client.close()
 
-    logging.info(json.dumps(inverter, indent=4, sort_keys=True))
+    logging.info(inverter)
     return True
 
 while True:


### PR DESCRIPTION
Currently in my SG5K-D inverter registers 5083 & 5084 are used for the amount *and* direction of power flowing through the Sungrow S100 smart meter.

If 5084 is 65535, then 5083 is treated as negative, and power is being exported to the grid.
If 5084 is 0, then 5083 is treated as positive, and power is being imported from the grid.

I just kinda kept poking around with dumping all hundred or so registers and kept turning the oven on and off until I narrowed down what registers were telling me importing vs exporting from the grid.

My logic around using the 'indicator' register and reading from it is potentially a bit flaky once the indicator register *is not* really close to the other register, but it works for me? /shrug

But I feel it's better than seeing if the register > 60,000 and then treating it as negative (seemed a bit too hacky for me)

Thoughts? Feelings?

Edit #1: Another thing this PR does is allows multiple 'transformations' on the register value

So you can have this 'overflow' modifier as well as a 'divide by' modifier, as well as future modifiers if we introduce any!