### PR TITLE
Basic Prometheus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ either install your own Grafana server or use their free
 A json export of solarspy.live Grafana dashboard is available under the grafana folder.
 The file will require editing to match your InfluxDb settings.
 
+### Prometheus and Grafana
+
+[Prometheus](https://prometheus.io/) can be enabled in config.py by setting `prometheus` to true. the data will then be exported on the port specified by `prometheus_port` (defaults to 8000).
+
+you can configure [Prometheus](https://prometheus.io/) to scrape this by adding a rule like this to your prometheus.yml
+```
+scrape_configs:
+  - job_name: 'solariot'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['localhost:8000']
+```
+
+alternatively if your using [Kubernetes](https://kubernetes.io/) you can use this [helm chart](https://github.com/slackerlinux85/HelmCharts/tree/master/helm-chart-sources/solariot)
+
 ### PVOutput.org
 
 We offer direct integration to publishing metrics to the 'Add Status' [API endpoint](https://pvoutput.org/help.html#api-addstatus) of PVOutput.

--- a/config-example.py
+++ b/config-example.py
@@ -11,6 +11,10 @@ scan_interval = 10
 # Optional:
 dweepy_uuid = "random-uuid"
 
+# optional
+# prometheus = True
+# prometheus_port = 8000
+
 # Optional:
 influxdb_ip = "192.168.1.128"
 influxdb_port = 8086

--- a/grafana/Solariot(Sungrow SG3K-S)-Prometheus.json
+++ b/grafana/Solariot(Sungrow SG3K-S)-Prometheus.json
@@ -1,0 +1,684 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.2.1"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_daily_power_yield",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Generated Today",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "megwatt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_total_power_yield",
+          "interval": "",
+          "legendFormat": "Total power yield",
+          "refId": "A"
+        }
+      ],
+      "title": "Generated All time",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "Voltage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 18,
+        "x": 6,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_grid_voltage",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Grid",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "solar_pv1_voltage",
+          "interval": "",
+          "legendFormat": "PV1",
+          "refId": "A"
+        }
+      ],
+      "title": "Voltage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "amp"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 6
+      },
+      "id": 15,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_inverter_current",
+          "interval": "",
+          "legendFormat": "Power(inverter)",
+          "refId": "A"
+        }
+      ],
+      "title": "Power(inverter current)",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              },
+              {
+                "color": "#EAB839",
+                "value": 90
+              },
+              {
+                "color": "semi-dark-orange",
+                "value": 100
+              },
+              {
+                "color": "#EF843C",
+                "value": 110
+              },
+              {
+                "color": "light-green",
+                "value": 120
+              },
+              {
+                "color": "dark-green",
+                "value": 130
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 140
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_total_pv_power",
+          "interval": "",
+          "legendFormat": "Power",
+          "refId": "A"
+        }
+      ],
+      "title": "Generating",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 11
+      },
+      "id": 11,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_grid_voltage",
+          "interval": "",
+          "legendFormat": "Voltage(Grid)",
+          "refId": "A"
+        }
+      ],
+      "title": "Voltage(Grid)",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "rothz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 11
+      },
+      "id": 13,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_grid_frequency",
+          "interval": "",
+          "legendFormat": "Frequency(Grid)",
+          "refId": "A"
+        }
+      ],
+      "title": "Frequency(Grid)",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "description": "Current",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "amp"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 6,
+        "y": 11
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_inverter_current",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Grid",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "solar_pv1_current",
+          "interval": "",
+          "legendFormat": "PV1",
+          "refId": "A"
+        }
+      ],
+      "title": "Current",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_internal_temp",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Inverter Temp",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 31,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Solariot(Sungrow SG3K-S)",
+  "uid": "SXBanhKnz",
+  "version": 6
+}

--- a/grafana/Solariot(Sungrow SG3K-S)-Prometheus.json
+++ b/grafana/Solariot(Sungrow SG3K-S)-Prometheus.json
@@ -172,7 +172,6 @@
     },
     {
       "datasource": null,
-      "description": "Voltage",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -182,7 +181,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "bars",
             "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
@@ -190,7 +189,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -213,20 +212,24 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "unit": "volt"
+          "unit": "watt"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
+        "h": 6,
         "w": 18,
         "x": 6,
         "y": 0
       },
-      "id": 3,
+      "id": 19,
       "options": {
         "legend": {
           "calcs": [
@@ -234,7 +237,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "right"
         },
         "tooltip": {
           "mode": "single"
@@ -243,21 +246,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "solar_grid_voltage",
-          "hide": false,
+          "expr": "solar_total_pv_power",
           "interval": "",
-          "legendFormat": "Grid",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "solar_pv1_voltage",
-          "interval": "",
-          "legendFormat": "PV1",
+          "legendFormat": "PV",
           "refId": "A"
         }
       ],
-      "title": "Voltage",
+      "title": "Generating",
       "type": "timeseries"
     },
     {
@@ -286,7 +281,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 8,
         "w": 3,
         "x": 0,
         "y": 6
@@ -336,31 +331,27 @@
               },
               {
                 "color": "red",
-                "value": 80
-              },
-              {
-                "color": "#EAB839",
-                "value": 90
-              },
-              {
-                "color": "semi-dark-orange",
                 "value": 100
               },
               {
-                "color": "#EF843C",
-                "value": 110
+                "color": "semi-dark-orange",
+                "value": 250
+              },
+              {
+                "color": "#EAB839",
+                "value": 500
               },
               {
                 "color": "light-green",
-                "value": 120
+                "value": 1000
               },
               {
                 "color": "dark-green",
-                "value": 130
+                "value": 1200
               },
               {
                 "color": "#6ED0E0",
-                "value": 140
+                "value": 2500
               }
             ]
           },
@@ -369,7 +360,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 8,
         "w": 3,
         "x": 3,
         "y": 6
@@ -403,6 +394,96 @@
     },
     {
       "datasource": null,
+      "description": "Voltage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 6
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_grid_voltage",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Grid",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "solar_pv1_voltage",
+          "interval": "",
+          "legendFormat": "PV1",
+          "refId": "A"
+        }
+      ],
+      "title": "Voltage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -419,7 +500,23 @@
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 200
+              },
+              {
+                "color": "light-green",
+                "value": 210
+              },
+              {
+                "color": "dark-green",
+                "value": 220
+              },
+              {
+                "color": "#EAB839",
+                "value": 240
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 250
               }
             ]
           },
@@ -428,10 +525,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 3,
+        "h": 7,
+        "w": 2,
         "x": 0,
-        "y": 11
+        "y": 14
       },
       "id": 11,
       "options": {
@@ -462,6 +559,63 @@
     },
     {
       "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 2,
+        "x": 2,
+        "y": 14
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "solar_internal_temp",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Inverter Temp",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -477,7 +631,15 @@
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 48
+              },
+              {
+                "color": "semi-dark-green",
+                "value": 50
+              },
+              {
+                "color": "dark-red",
+                "value": 52
               }
             ]
           },
@@ -486,10 +648,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 3,
-        "y": 11
+        "h": 7,
+        "w": 2,
+        "x": 4,
+        "y": 14
       },
       "id": 13,
       "options": {
@@ -569,10 +731,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 18,
         "x": 6,
-        "y": 11
+        "y": 14
       },
       "id": 2,
       "options": {
@@ -582,7 +744,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "right"
         },
         "tooltip": {
           "mode": "single"
@@ -607,63 +769,6 @@
       ],
       "title": "Current",
       "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 0,
-        "y": 16
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.2.1",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "solar_internal_temp",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Inverter Temp",
-      "type": "stat"
     }
   ],
   "schemaVersion": 31,
@@ -680,5 +785,5 @@
   "timezone": "browser",
   "title": "Solariot(Sungrow SG3K-S)",
   "uid": "SXBanhKnz",
-  "version": 6
+  "version": 10
 }

--- a/grafana/Solariot(Sungrow SG3K-S)-Prometheus.json
+++ b/grafana/Solariot(Sungrow SG3K-S)-Prometheus.json
@@ -771,6 +771,7 @@
       "type": "timeseries"
     }
   ],
+  "refresh": "30s",
   "schemaVersion": 31,
   "style": "dark",
   "tags": [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 paho-mqtt>=1.5.1
 pymodbus==2.4.0
 dweepy>=0.3.0
+prometheus-client>=0.9
 influxdb>=5.3.1
 SungrowModbusTcpClient>=0.1.5


### PR DESCRIPTION
this pull request adds support for Prometheus. it works fine here but is now time to get it tested on more hardware/enviroments for consideration to be upstreamed

it should export all metrics(except text) in a way Prometheus can scrape and should hopefully work with all inverters by creating a gauge when its first seen. README.md has been updated with an example configuration aswell as a mention to a helm chart for Kubernetes that doesn't need any configuration(uses a servicemonitor to hook into Prometheus) feel free to remove that if you want. counters are also reset when inverter isnt contactable

the helm chart should also work fine with other data sources but has only been tested with Prometheus

also included is a (very) basic grafana dashboard designed for the Sungrow SG3K-S using the Prometheus data source as an example

prebuilt docker images(tagged with feature-Prometheus ) can be found on my branch for testing: https://github.com/slackerlinux85/solariot/pkgs/container/solariot
or just set prometheus = true in your config. then run solariot and check http://localhost:8000 all the metrics should be exported to there by default