### PR TITLE
Remove erroneous space in metric name

### DIFF
--- a/modbus-sungrow-sh10rt.py
+++ b/modbus-sungrow-sh10rt.py
@@ -31,7 +31,7 @@ read_register = {
   "13017": "daily_use_energy_10",
   "13018": "total_use_energy_10",
   "13020": "battery_voltage_10",
-  "13021": "battery current_10",
+  "13021": "battery_current_10",
   "13022": "battery_power",
   "13023": "battery_level_10",
   "13024": "battery_health_10",

--- a/modbus-sungrow-sh5k.py
+++ b/modbus-sungrow-sh5k.py
@@ -44,7 +44,7 @@ read_register = {
   "13018": "total_use_energy_10",
   "13019": "13019",
   "13020": "battery_voltage_10",
-  "13021": "battery current_10",
+  "13021": "battery_current_10",
   "13022": "battery_power",
   "13023": "battery_level_10",
   "13024": "battery_health_10",


### PR DESCRIPTION
Prevents failure during Prometheus metric collection.

```python
Exception in thread Thread-371:
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.9/threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "/solariot/solariot.py", line 424, in publish_prometheus
    result = prom_client.publish_status(inverter)
  File "/solariot/solariot.py", line 146, in publish_status
    self.metric_mappings[key] =  Gauge('solar_' + key, key)
  File "/usr/local/lib/python3.9/site-packages/prometheus_client/metrics.py", line 355, in __init__
    super(Gauge, self).__init__(
  File "/usr/local/lib/python3.9/site-packages/prometheus_client/metrics.py", line 123, in __init__
    raise ValueError('Invalid metric name: ' + self._name)
ValueError: Invalid metric name: solar_battery current_10
```