### PR TITLE
Add pvoutput support for Sungrow SG8KD

### DIFF
--- a/modbus-sungrow-sg8kd.py
+++ b/modbus-sungrow-sg8kd.py
@@ -48,3 +48,18 @@ scan = """{
   ]
 }"""
 
+# For field mappings, see
+# https://pvoutput.org/help/api_specification.html#add-status-service
+pvoutput = {
+  "Power Generation": "total_active_power",
+  "Power Consumption": "house_loads",
+  "Voltage": "grid_voltage",
+  "Temperature": "internal_temp",
+  "Extended Value v7": "grid_frequency",
+  "Extended Value v8": "internal_temp",
+  "Extended Value v9": "pv1_voltage",
+  "Extended Value v10": "pv1_current",
+  "Extended Value v11": "pv2_voltage",
+  "Extended Value v12": "pv2_current"
+}
+


### PR DESCRIPTION
As per title, this adds the necessary mappings in order to export data from Sungrow SG8KD inverter to the pvoutput API.

Has been running for a day and can confirm that it is operating great, see screenshot below:

![2022-06-30](https://user-images.githubusercontent.com/6028967/176601774-613d945b-ef4a-4041-99c6-e6118dc4e472.png)
