### PR TITLE
Added support to configure logging from config.py

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -48,3 +48,26 @@ influxdb_verify_ssl = False
 #json_file = "telemetry.json"
 # This option, when set to True, writes new lines to the end of the current file.  When set to False you get a single (latest) line per file
 #append_log = False
+
+
+# Logging config. If not specified, default is being used.
+logger_config = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'default': {
+            'format': '[%(asctime)s] %(levelname)s - %(message)s',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'default',
+            'level': 'INFO',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
+}


### PR DESCRIPTION
Added support to configure logging from config.py
Logging configuration can be configured using the _logger_config_ in the config.py.

Logging configuration is optional, if not configured, it falls back to the existing default logging config.
@meltaxa I am not sure if there is still need to maintain the existing logging setup (logging.basicConfig(level=log_level...), please advice.

Personally, would suggest to remove the use of logging.basicConfig together with the "--verbose" runtime argument and let the logging config be driver by config.py, since it's more confusing to have two ways of configuring the logger, one from code and the other from config.py.